### PR TITLE
Add Gitflow workflows for release and hotfix management

### DIFF
--- a/.github/workflows/gitflow-hotfix.yml
+++ b/.github/workflows/gitflow-hotfix.yml
@@ -11,7 +11,11 @@ on:
           - hotfix-start
           - hotfix-finish
       version:
-        description: 'Hotfix version (only for hotfix-start, e.g., 1.17.1)'
+        description: 'Hotfix version (for hotfix-start and hotfix-finish, e.g., 1.17.1)'
+        required: false
+        type: string
+      branch:
+        description: 'Hotfix branch name (for hotfix-finish, e.g., hotfix/1.17.1)'
         required: false
         type: string
 
@@ -49,4 +53,11 @@ jobs:
     - name: Hotfix Finish
       if: inputs.action == 'hotfix-finish'
       run: |
-        mvn gitflow:hotfix-finish -B -DpushRemote=true
+        if [ -n "${{ inputs.branch }}" ]; then
+          mvn gitflow:hotfix-finish -B -DpushRemote=true -DhotfixBranch=${{ inputs.branch }}
+        elif [ -n "${{ inputs.version }}" ]; then
+          mvn gitflow:hotfix-finish -B -DpushRemote=true -DhotfixVersion=${{ inputs.version }}
+        else
+          echo "Error: Either branch or version must be specified for hotfix-finish"
+          exit 1
+        fi

--- a/.github/workflows/gitflow-hotfix.yml
+++ b/.github/workflows/gitflow-hotfix.yml
@@ -1,0 +1,52 @@
+name: Gitflow Hotfix
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Gitflow action to perform'
+        required: true
+        type: choice
+        options:
+          - hotfix-start
+          - hotfix-finish
+      version:
+        description: 'Hotfix version (only for hotfix-start, e.g., 1.17.1)'
+        required: false
+        type: string
+
+jobs:
+  gitflow-hotfix:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Set up JDK 8
+      uses: actions/setup-java@v4
+      with:
+        java-version: '8'
+        distribution: 'temurin'
+        cache: maven
+    
+    - name: Configure Git
+      run: |
+        git config user.name "${{ github.actor }}"
+        git config user.email "${{ github.actor }}@users.noreply.github.com"
+    
+    - name: Hotfix Start
+      if: inputs.action == 'hotfix-start'
+      run: |
+        if [ -z "${{ inputs.version }}" ]; then
+          mvn gitflow:hotfix-start -B
+        else
+          mvn gitflow:hotfix-start -B -DhotfixVersion=${{ inputs.version }}
+        fi
+    
+    - name: Hotfix Finish
+      if: inputs.action == 'hotfix-finish'
+      run: |
+        mvn gitflow:hotfix-finish -B -DpushRemote=true

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -1,0 +1,52 @@
+name: Gitflow Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Gitflow action to perform'
+        required: true
+        type: choice
+        options:
+          - release-start
+          - release-finish
+      version:
+        description: 'Release version (only for release-start, e.g., 1.18.0)'
+        required: false
+        type: string
+
+jobs:
+  gitflow-release:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Set up JDK 8
+      uses: actions/setup-java@v4
+      with:
+        java-version: '8'
+        distribution: 'temurin'
+        cache: maven
+    
+    - name: Configure Git
+      run: |
+        git config user.name "${{ github.actor }}"
+        git config user.email "${{ github.actor }}@users.noreply.github.com"
+    
+    - name: Release Start
+      if: inputs.action == 'release-start'
+      run: |
+        if [ -z "${{ inputs.version }}" ]; then
+          mvn gitflow:release-start -B
+        else
+          mvn gitflow:release-start -B -DreleaseVersion=${{ inputs.version }}
+        fi
+    
+    - name: Release Finish
+      if: inputs.action == 'release-finish'
+      run: |
+        mvn gitflow:release-finish -B -DpushRemote=true

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -11,7 +11,11 @@ on:
           - release-start
           - release-finish
       version:
-        description: 'Release version (only for release-start, e.g., 1.18.0)'
+        description: 'Release version (for release-start and release-finish, e.g., 1.18.0)'
+        required: false
+        type: string
+      branch:
+        description: 'Release branch name (for release-finish, e.g., release/1.18.0)'
         required: false
         type: string
 
@@ -49,4 +53,11 @@ jobs:
     - name: Release Finish
       if: inputs.action == 'release-finish'
       run: |
-        mvn gitflow:release-finish -B -DpushRemote=true
+        if [ -n "${{ inputs.branch }}" ]; then
+          mvn gitflow:release-finish -B -DpushRemote=true -DreleaseBranch=${{ inputs.branch }}
+        elif [ -n "${{ inputs.version }}" ]; then
+          mvn gitflow:release-finish -B -DpushRemote=true -DreleaseVersion=${{ inputs.version }}
+        else
+          echo "Error: Either branch or version must be specified for release-finish"
+          exit 1
+        fi


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflows for gitflow operations
- Enable automated release and hotfix management through GitHub UI

## Changes
- Added  for release start/finish
- Added  for hotfix start/finish
- Both workflows use manual triggers (workflow_dispatch)
- Only users with write access can execute these workflows

## Features
- Manual trigger via GitHub Actions tab
- Optional version parameter for start actions
- Automatic push to remote on finish operations
- Configured with gitflow-maven-plugin settings from pom.xml

## Security
- Workflows can only be triggered by users with write permissions
- Public users cannot execute these actions