### PR TITLE
Add Maven batch mode and no-transfer-progress flags to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,10 @@ jobs:
         cache: maven
     
     - name: Build with Maven
-      run: mvn clean compile
+      run: mvn clean compile -B -ntp
     
     - name: Run tests
-      run: mvn test
+      run: mvn test -B -ntp
     
     - name: Package
-      run: mvn package -DskipTests
+      run: mvn package -DskipTests -B -ntp

--- a/.github/workflows/gitflow-hotfix.yml
+++ b/.github/workflows/gitflow-hotfix.yml
@@ -45,18 +45,18 @@ jobs:
       if: inputs.action == 'hotfix-start'
       run: |
         if [ -z "${{ inputs.version }}" ]; then
-          mvn gitflow:hotfix-start -B
+          mvn gitflow:hotfix-start -B -ntp
         else
-          mvn gitflow:hotfix-start -B -DhotfixVersion=${{ inputs.version }}
+          mvn gitflow:hotfix-start -B -ntp -DhotfixVersion=${{ inputs.version }}
         fi
     
     - name: Hotfix Finish
       if: inputs.action == 'hotfix-finish'
       run: |
         if [ -n "${{ inputs.branch }}" ]; then
-          mvn gitflow:hotfix-finish -B -DpushRemote=true -DhotfixBranch=${{ inputs.branch }}
+          mvn gitflow:hotfix-finish -B -ntp -DpushRemote=true -DhotfixBranch=${{ inputs.branch }}
         elif [ -n "${{ inputs.version }}" ]; then
-          mvn gitflow:hotfix-finish -B -DpushRemote=true -DhotfixVersion=${{ inputs.version }}
+          mvn gitflow:hotfix-finish -B -ntp -DpushRemote=true -DhotfixVersion=${{ inputs.version }}
         else
           echo "Error: Either branch or version must be specified for hotfix-finish"
           exit 1

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -45,18 +45,18 @@ jobs:
       if: inputs.action == 'release-start'
       run: |
         if [ -z "${{ inputs.version }}" ]; then
-          mvn gitflow:release-start -B
+          mvn gitflow:release-start -B -ntp
         else
-          mvn gitflow:release-start -B -DreleaseVersion=${{ inputs.version }}
+          mvn gitflow:release-start -B -ntp -DreleaseVersion=${{ inputs.version }}
         fi
     
     - name: Release Finish
       if: inputs.action == 'release-finish'
       run: |
         if [ -n "${{ inputs.branch }}" ]; then
-          mvn gitflow:release-finish -B -DpushRemote=true -DreleaseBranch=${{ inputs.branch }}
+          mvn gitflow:release-finish -B -ntp -DpushRemote=true -DreleaseBranch=${{ inputs.branch }}
         elif [ -n "${{ inputs.version }}" ]; then
-          mvn gitflow:release-finish -B -DpushRemote=true -DreleaseVersion=${{ inputs.version }}
+          mvn gitflow:release-finish -B -ntp -DpushRemote=true -DreleaseVersion=${{ inputs.version }}
         else
           echo "Error: Either branch or version must be specified for release-finish"
           exit 1


### PR DESCRIPTION
## Summary
- Add Maven batch mode (-B) flag for non-interactive execution
- Add no-transfer-progress (-ntp) flag to reduce log verbosity

## Changes
- Updated all Maven commands in CI workflow
- Updated all Maven commands in gitflow-release workflow
- Updated all Maven commands in gitflow-hotfix workflow

## Benefits
- Cleaner CI logs without download progress spam
- Ensures non-interactive execution in automated environments
- Faster log processing and better readability