### PR TITLE
Add Maven batch mode flags and fix gitflow workflows

### DIFF
--- a/.github/workflows/gitflow-hotfix.yml
+++ b/.github/workflows/gitflow-hotfix.yml
@@ -11,11 +11,7 @@ on:
           - hotfix-start
           - hotfix-finish
       version:
-        description: 'Hotfix version (for hotfix-start and hotfix-finish, e.g., 1.17.1)'
-        required: false
-        type: string
-      branch:
-        description: 'Hotfix branch name (REQUIRED for hotfix-finish, e.g., hotfix/1.17.1)'
+        description: 'Hotfix version (REQUIRED for both hotfix-start and hotfix-finish, e.g., 1.17.1)'
         required: false
         type: string
 
@@ -53,25 +49,21 @@ jobs:
     - name: Hotfix Finish
       if: inputs.action == 'hotfix-finish'
       run: |
-        # For hotfix-finish, we need to determine the branch
-        if [ -n "${{ inputs.branch }}" ]; then
-          echo "Using provided branch: ${{ inputs.branch }}"
-          mvn gitflow:hotfix-finish -B -ntp -DpushRemote=true -DhotfixBranch=${{ inputs.branch }}
-        elif [ -n "${{ inputs.version }}" ]; then
+        # For hotfix-finish, we need the version
+        if [ -n "${{ inputs.version }}" ]; then
           echo "Using provided version: ${{ inputs.version }}"
           mvn gitflow:hotfix-finish -B -ntp -DpushRemote=true -DhotfixVersion=${{ inputs.version }}
         else
-          # Try to detect current branch if on a hotfix branch
+          # Try to detect current branch and extract version
           CURRENT_BRANCH=$(git branch --show-current)
           if [[ "$CURRENT_BRANCH" == hotfix/* ]]; then
-            echo "Auto-detected hotfix branch: $CURRENT_BRANCH"
-            mvn gitflow:hotfix-finish -B -ntp -DpushRemote=true -DhotfixBranch=$CURRENT_BRANCH
+            VERSION=$(echo "$CURRENT_BRANCH" | sed 's/^hotfix\///')
+            echo "Auto-detected hotfix version from current branch: $VERSION"
+            mvn gitflow:hotfix-finish -B -ntp -DpushRemote=true -DhotfixVersion=$VERSION
           else
-            echo "Error: Cannot auto-detect hotfix branch. Either 'branch' or 'version' must be specified for hotfix-finish."
+            echo "Error: 'version' parameter is required for hotfix-finish."
             echo "Current branch: $CURRENT_BRANCH"
-            echo "Please provide either:"
-            echo "  - branch: The full hotfix branch name (e.g., hotfix/1.17.1)"
-            echo "  - version: The version number (e.g., 1.17.1)"
+            echo "Please provide the version number (e.g., 1.17.1)"
             exit 1
           fi
         fi

--- a/.github/workflows/gitflow-hotfix.yml
+++ b/.github/workflows/gitflow-hotfix.yml
@@ -15,7 +15,7 @@ on:
         required: false
         type: string
       branch:
-        description: 'Hotfix branch name (for hotfix-finish, e.g., hotfix/1.17.1)'
+        description: 'Hotfix branch name (REQUIRED for hotfix-finish, e.g., hotfix/1.17.1)'
         required: false
         type: string
 
@@ -53,11 +53,25 @@ jobs:
     - name: Hotfix Finish
       if: inputs.action == 'hotfix-finish'
       run: |
+        # For hotfix-finish, we need to determine the branch
         if [ -n "${{ inputs.branch }}" ]; then
+          echo "Using provided branch: ${{ inputs.branch }}"
           mvn gitflow:hotfix-finish -B -ntp -DpushRemote=true -DhotfixBranch=${{ inputs.branch }}
         elif [ -n "${{ inputs.version }}" ]; then
+          echo "Using provided version: ${{ inputs.version }}"
           mvn gitflow:hotfix-finish -B -ntp -DpushRemote=true -DhotfixVersion=${{ inputs.version }}
         else
-          echo "Error: Either branch or version must be specified for hotfix-finish"
-          exit 1
+          # Try to detect current branch if on a hotfix branch
+          CURRENT_BRANCH=$(git branch --show-current)
+          if [[ "$CURRENT_BRANCH" == hotfix/* ]]; then
+            echo "Auto-detected hotfix branch: $CURRENT_BRANCH"
+            mvn gitflow:hotfix-finish -B -ntp -DpushRemote=true -DhotfixBranch=$CURRENT_BRANCH
+          else
+            echo "Error: Cannot auto-detect hotfix branch. Either 'branch' or 'version' must be specified for hotfix-finish."
+            echo "Current branch: $CURRENT_BRANCH"
+            echo "Please provide either:"
+            echo "  - branch: The full hotfix branch name (e.g., hotfix/1.17.1)"
+            echo "  - version: The version number (e.g., 1.17.1)"
+            exit 1
+          fi
         fi

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -15,7 +15,7 @@ on:
         required: false
         type: string
       branch:
-        description: 'Release branch name (for release-finish, e.g., release/1.18.0)'
+        description: 'Release branch name (REQUIRED for release-finish, e.g., release/1.18.0)'
         required: false
         type: string
 
@@ -53,11 +53,25 @@ jobs:
     - name: Release Finish
       if: inputs.action == 'release-finish'
       run: |
+        # For release-finish, we need to determine the branch
         if [ -n "${{ inputs.branch }}" ]; then
+          echo "Using provided branch: ${{ inputs.branch }}"
           mvn gitflow:release-finish -B -ntp -DpushRemote=true -DreleaseBranch=${{ inputs.branch }}
         elif [ -n "${{ inputs.version }}" ]; then
+          echo "Using provided version: ${{ inputs.version }}"
           mvn gitflow:release-finish -B -ntp -DpushRemote=true -DreleaseVersion=${{ inputs.version }}
         else
-          echo "Error: Either branch or version must be specified for release-finish"
-          exit 1
+          # Try to detect current branch if on a release branch
+          CURRENT_BRANCH=$(git branch --show-current)
+          if [[ "$CURRENT_BRANCH" == release/* ]]; then
+            echo "Auto-detected release branch: $CURRENT_BRANCH"
+            mvn gitflow:release-finish -B -ntp -DpushRemote=true -DreleaseBranch=$CURRENT_BRANCH
+          else
+            echo "Error: Cannot auto-detect release branch. Either 'branch' or 'version' must be specified for release-finish."
+            echo "Current branch: $CURRENT_BRANCH"
+            echo "Please provide either:"
+            echo "  - branch: The full release branch name (e.g., release/1.18.0)"
+            echo "  - version: The version number (e.g., 1.18.0)"
+            exit 1
+          fi
         fi


### PR DESCRIPTION
## Summary
- Add Maven batch mode (-B) and no-transfer-progress (-ntp) flags to all workflows
- Fix gitflow hotfix-finish to use hotfixVersion parameter correctly
- Add auto-detection of version from branch names

## Changes

### Maven Flags
- Added  flag for non-interactive batch mode execution
- Added  flag to reduce log verbosity by hiding transfer progress
- Applied to all Maven commands in CI, release, and hotfix workflows

### Gitflow Hotfix Fix
- Removed branch parameter, simplified to only use version parameter
- hotfix-finish now always uses  (not )
- Auto-detects version from current branch name (e.g., hotfix/1.17.1 → 1.17.1)
- Better error messages with clear instructions

### Gitflow Release Enhancement
- Added auto-detection for release branches
- Improved error handling with helpful messages

## Benefits
- Cleaner CI logs without download progress spam
- Non-interactive execution in automated environments
- Fixes the failing hotfix-finish workflow
- Simpler and more intuitive parameter usage