### PR TITLE
Fix gitflow workflows: Add Maven flags and branch checkout

### DIFF
--- a/.github/workflows/gitflow-hotfix.yml
+++ b/.github/workflows/gitflow-hotfix.yml
@@ -25,6 +25,9 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
     
+    - name: Fetch all branches
+      run: git fetch --all
+    
     - name: Set up JDK 8
       uses: actions/setup-java@v4
       with:
@@ -51,19 +54,27 @@ jobs:
       run: |
         # For hotfix-finish, we need the version
         if [ -n "${{ inputs.version }}" ]; then
+          HOTFIX_BRANCH="hotfix/${{ inputs.version }}"
           echo "Using provided version: ${{ inputs.version }}"
-          mvn gitflow:hotfix-finish -B -ntp -DpushRemote=true -DhotfixVersion=${{ inputs.version }}
-        else
-          # Try to detect current branch and extract version
-          CURRENT_BRANCH=$(git branch --show-current)
-          if [[ "$CURRENT_BRANCH" == hotfix/* ]]; then
-            VERSION=$(echo "$CURRENT_BRANCH" | sed 's/^hotfix\///')
-            echo "Auto-detected hotfix version from current branch: $VERSION"
-            mvn gitflow:hotfix-finish -B -ntp -DpushRemote=true -DhotfixVersion=$VERSION
+          echo "Checking for hotfix branch: $HOTFIX_BRANCH"
+          
+          # Check if the hotfix branch exists
+          if git show-ref --verify --quiet "refs/remotes/origin/$HOTFIX_BRANCH"; then
+            echo "Found remote hotfix branch: $HOTFIX_BRANCH"
+            git checkout "$HOTFIX_BRANCH"
+          elif git show-ref --verify --quiet "refs/heads/$HOTFIX_BRANCH"; then
+            echo "Found local hotfix branch: $HOTFIX_BRANCH"
+            git checkout "$HOTFIX_BRANCH"
           else
-            echo "Error: 'version' parameter is required for hotfix-finish."
-            echo "Current branch: $CURRENT_BRANCH"
-            echo "Please provide the version number (e.g., 1.17.1)"
+            echo "Error: Hotfix branch '$HOTFIX_BRANCH' not found!"
+            echo "Available remote branches:"
+            git branch -r | grep hotfix/ || echo "No hotfix branches found"
             exit 1
           fi
+          
+          mvn gitflow:hotfix-finish -B -ntp -DpushRemote=true -DhotfixVersion=${{ inputs.version }}
+        else
+          echo "Error: 'version' parameter is required for hotfix-finish."
+          echo "Please provide the version number (e.g., 1.17.1)"
+          exit 1
         fi

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -29,6 +29,9 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
     
+    - name: Fetch all branches
+      run: git fetch --all
+    
     - name: Set up JDK 8
       uses: actions/setup-java@v4
       with:
@@ -55,23 +58,48 @@ jobs:
       run: |
         # For release-finish, we need to determine the branch
         if [ -n "${{ inputs.branch }}" ]; then
-          echo "Using provided branch: ${{ inputs.branch }}"
-          mvn gitflow:release-finish -B -ntp -DpushRemote=true -DreleaseBranch=${{ inputs.branch }}
-        elif [ -n "${{ inputs.version }}" ]; then
-          echo "Using provided version: ${{ inputs.version }}"
-          mvn gitflow:release-finish -B -ntp -DpushRemote=true -DreleaseVersion=${{ inputs.version }}
-        else
-          # Try to detect current branch if on a release branch
-          CURRENT_BRANCH=$(git branch --show-current)
-          if [[ "$CURRENT_BRANCH" == release/* ]]; then
-            echo "Auto-detected release branch: $CURRENT_BRANCH"
-            mvn gitflow:release-finish -B -ntp -DpushRemote=true -DreleaseBranch=$CURRENT_BRANCH
+          RELEASE_BRANCH="${{ inputs.branch }}"
+          echo "Using provided branch: $RELEASE_BRANCH"
+          
+          # Check if the release branch exists and checkout
+          if git show-ref --verify --quiet "refs/remotes/origin/$RELEASE_BRANCH"; then
+            echo "Found remote release branch: $RELEASE_BRANCH"
+            git checkout "$RELEASE_BRANCH"
+          elif git show-ref --verify --quiet "refs/heads/$RELEASE_BRANCH"; then
+            echo "Found local release branch: $RELEASE_BRANCH"
+            git checkout "$RELEASE_BRANCH"
           else
-            echo "Error: Cannot auto-detect release branch. Either 'branch' or 'version' must be specified for release-finish."
-            echo "Current branch: $CURRENT_BRANCH"
-            echo "Please provide either:"
-            echo "  - branch: The full release branch name (e.g., release/1.18.0)"
-            echo "  - version: The version number (e.g., 1.18.0)"
+            echo "Error: Release branch '$RELEASE_BRANCH' not found!"
+            echo "Available remote branches:"
+            git branch -r | grep release/ || echo "No release branches found"
             exit 1
           fi
+          
+          mvn gitflow:release-finish -B -ntp -DpushRemote=true -DreleaseBranch=${{ inputs.branch }}
+        elif [ -n "${{ inputs.version }}" ]; then
+          RELEASE_BRANCH="release/${{ inputs.version }}"
+          echo "Using provided version: ${{ inputs.version }}"
+          echo "Checking for release branch: $RELEASE_BRANCH"
+          
+          # Check if the release branch exists and checkout
+          if git show-ref --verify --quiet "refs/remotes/origin/$RELEASE_BRANCH"; then
+            echo "Found remote release branch: $RELEASE_BRANCH"
+            git checkout "$RELEASE_BRANCH"
+          elif git show-ref --verify --quiet "refs/heads/$RELEASE_BRANCH"; then
+            echo "Found local release branch: $RELEASE_BRANCH"
+            git checkout "$RELEASE_BRANCH"
+          else
+            echo "Error: Release branch '$RELEASE_BRANCH' not found!"
+            echo "Available remote branches:"
+            git branch -r | grep release/ || echo "No release branches found"
+            exit 1
+          fi
+          
+          mvn gitflow:release-finish -B -ntp -DpushRemote=true -DreleaseVersion=${{ inputs.version }}
+        else
+          echo "Error: Either 'branch' or 'version' must be specified for release-finish."
+          echo "Please provide either:"
+          echo "  - branch: The full release branch name (e.g., release/1.18.0)"
+          echo "  - version: The version number (e.g., 1.18.0)"
+          exit 1
         fi


### PR DESCRIPTION
## Summary
- Add Maven batch mode (-B) and no-transfer-progress (-ntp) flags
- Fix gitflow finish workflows by checking out the correct branch
- Simplify hotfix workflow to use hotfixVersion parameter only

## Problem Solved
The gitflow finish actions were failing because they were running on the default branch (develop) instead of the actual hotfix/release branch. The gitflow-maven-plugin requires being on the correct branch to execute finish commands.

## Changes

### Maven Improvements
- Added  flag for non-interactive batch mode
- Added  flag to reduce log verbosity
- Applied to all Maven commands in all workflows

### Gitflow Workflow Fixes
- Added `git fetch --all` to ensure all remote branches are available
- **hotfix-finish**: Now checks out the hotfix branch before finishing
- **release-finish**: Now checks out the release branch before finishing
- Removed branch parameter from hotfix workflow (uses version only)
- Added detailed error messages showing available branches

### Example Fix
When running hotfix-finish for version 1.16.2:
1. Constructs branch name: hotfix/1.16.2
2. Checks if branch exists (remote or local)
3. Checks out the branch
4. Runs: mvn gitflow:hotfix-finish -DhotfixVersion=1.16.2

## Testing
The workflow will now properly:
- Find and checkout hotfix/1.16.2 before finishing
- Show helpful error messages if branch doesn't exist
- List available branches for debugging